### PR TITLE
:bug: (chart): .Chart.Version should not be used with vcluster templating

### DIFF
--- a/.github/workflows/release.workflow.yml
+++ b/.github/workflows/release.workflow.yml
@@ -69,10 +69,11 @@ jobs:
             ${{ runner.os }}-asdf-
       - uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
 
-      # NOTE: update all versions inside Chart.yaml
+      # NOTE: update all versions inside the Helm chart
       - name: Bump `charts/belug-apps/Chart.yaml` to ${{ inputs.version }}
         run: |
           sed --regexp-extended --in-place 's/^((app)?[vV]ersion).+/\1: ${{ inputs.version }}/g' charts/belug-apps/Chart.yaml
+          sed --regexp-extended --in-place  's/^(    version):.+$/\1: ${{ inputs.version }}/g' charts/belug-apps/values.yaml
 
       # NOTE: rebuild components & manifests and inject them to `charts/belug-apps/values.yaml`
       - name: Release components & manifests

--- a/.github/workflows/release.workflow.yml
+++ b/.github/workflows/release.workflow.yml
@@ -69,26 +69,7 @@ jobs:
             ${{ runner.os }}-asdf-
       - uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
 
-      # NOTE: update all versions inside the Helm chart
-      - name: Bump `charts/belug-apps/Chart.yaml` to ${{ inputs.version }}
-        run: |
-          sed --regexp-extended --in-place 's/^((app)?[vV]ersion).+/\1: ${{ inputs.version }}/g' charts/belug-apps/Chart.yaml
-          sed --regexp-extended --in-place  's/^(    version):.+$/\1: ${{ inputs.version }}/g' charts/belug-apps/values.yaml
-
-      # NOTE: rebuild components & manifests and inject them to `charts/belug-apps/values.yaml`
-      - name: Release components & manifests
-        run: just build
-
-      # NOTE: generate changelog
-      - name: Update `CHANGELOG.md` with the release v${{ inputs.version }}
-        run: git-chglog --next-tag v${{ inputs.version }} > CHANGELOG.md
-
-      # NOTE: update README
-      - name: Update `README.md` with the release v${{ inputs.version }} (only release)
-        run: |
-          [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-            || exit 0 \
-            && sed -E 's/version=[^"]+/version=v${{ inputs.version }}/g' README.md
+      - run: just release ${{ inputs.version }}
 
       # NOTE: commit all changes
       - uses: EndBug/add-and-commit@61a88be553afe4206585b31aa72387c64295d08b # tag=v9.1.1

--- a/.justfile
+++ b/.justfile
@@ -14,6 +14,18 @@ build environment="production":
     @just _utils_chart_inject_components
     @just _utils_chart_inject_manifests {{ if environment =~ 'prod.*' { "default" } else { "dev" } }}
 
+# made all changes required to release Belug-Apps
+release version: #build
+    # update version inside Chart.yml and values.yml
+    sed --regexp-extended --in-place 's/^((app)?[vV]ersion).+/\1: {{version}}/g' charts/belug-apps/Chart.yaml
+    sed --regexp-extended --in-place  's/^(    version):.+$/\1: {{version}}/g' charts/belug-apps/values.yaml
+
+    # update CHANGELOG.md
+    git-chglog --next-tag v{{version}} > CHANGELOG.md
+
+    # update README.md (ignore pre-release)
+    {{ if version =~ '^[0-9]+\.[0-9]+\.[0-9]+$' { "sed --regexp-extended --in-place 's/version=[^\"]+/version=v" + version + "/g' README.md" } else { "# ignore on pre-release" } }}
+
 
 ###############################################################################
 # [develop] - manage the lifecycle of the development environment

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <h4 align="center">Belug-Apps - TrueCharts alternative for TrueNAS SCALE</h4>
 
 <div align="center">
-  <a href="https://github.com/belug-apps/belug-apps/issues/new?https://github.com/xunleii/belug-apps-test/issues/new?assignees=&labels=type%3A+bug%2Cstate%3A+needs+triage&template=01_BUG_REPORT.yml&title=%F0%9F%90%9B+&version=v0.1.0">Report a Bug</a> ·
+  <a href="https://github.com/belug-apps/belug-apps/issues/new?https://github.com/xunleii/belug-apps-test/issues/new?assignees=&labels=type%3A+bug%2Cstate%3A+needs+triage&template=01_BUG_REPORT.yml&title=%F0%9F%90%9B+&version=v0.3.0">Report a Bug</a> ·
   <a href="https://github.com/belug-apps/belug-apps-test/issues/new?assignees=&labels=type%3A+enhancement&template=02_FEATURE_REQUEST.yml&title=%E2%9C%A8+">Request a Feature</a> ·
   <a href="https://github.com/belug-apps/belug-apps/discussions">Ask a Question</a>
   <br/>

--- a/charts/belug-apps/values.yaml
+++ b/charts/belug-apps/values.yaml
@@ -3,7 +3,7 @@
 # Default vcluster configuration for TrueNAS
 vcluster:
   belug-apps:
-    version: 0.4.0
+    version: 0.3.0
 
   # Virtual Cluster (k3s) configuration
   vcluster:

--- a/charts/belug-apps/values.yaml
+++ b/charts/belug-apps/values.yaml
@@ -2,6 +2,9 @@
 ---
 # Default vcluster configuration for TrueNAS
 vcluster:
+  belug-apps:
+    version: 0.4.0
+
   # Virtual Cluster (k3s) configuration
   vcluster:
     # NOTE: this is configured directly through the UI
@@ -229,8 +232,8 @@ vcluster:
           app.kubernetes.io/instance: '{{ .Release.Name }}'
           app.kubernetes.io/managed-by: '{{ .Release.Service }}'
           app.kubernetes.io/name: belugapps
-          app.kubernetes.io/version: '{{ .Chart.Version }}'
-          helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+          app.kubernetes.io/version: '{{ .belug-apps.version }}'
+          helm.sh/chart: belug-apps-{{ .belug-apps.version }}
         name: kubeapps-system
       ---
       apiVersion: v1
@@ -240,8 +243,8 @@ vcluster:
           app.kubernetes.io/instance: '{{ .Release.Name }}'
           app.kubernetes.io/managed-by: '{{ .Release.Service }}'
           app.kubernetes.io/name: belugapps
-          app.kubernetes.io/version: '{{ .Chart.Version }}'
-          helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+          app.kubernetes.io/version: '{{ .belug-apps.version }}'
+          helm.sh/chart: belug-apps-{{ .belug-apps.version }}
         name: truenas-creds
         namespace: kubeapps-system
       stringData:
@@ -256,8 +259,8 @@ vcluster:
           app.kubernetes.io/instance: '{{ .Release.Name }}'
           app.kubernetes.io/managed-by: '{{ .Release.Service }}'
           app.kubernetes.io/name: belugapps
-          app.kubernetes.io/version: '{{ .Chart.Version }}'
-          helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+          app.kubernetes.io/version: '{{ .belug-apps.version }}'
+          helm.sh/chart: belug-apps-{{ .belug-apps.version }}
         name: api-proxy
         namespace: kubeapps-system
       spec:
@@ -268,8 +271,8 @@ vcluster:
           app.kubernetes.io/instance: '{{ .Release.Name }}'
           app.kubernetes.io/managed-by: '{{ .Release.Service }}'
           app.kubernetes.io/name: belugapps
-          app.kubernetes.io/version: '{{ .Chart.Version }}'
-          helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+          app.kubernetes.io/version: '{{ .belug-apps.version }}'
+          helm.sh/chart: belug-apps-{{ .belug-apps.version }}
       ---
       apiVersion: apps/v1
       kind: Deployment
@@ -279,8 +282,8 @@ vcluster:
           app.kubernetes.io/instance: '{{ .Release.Name }}'
           app.kubernetes.io/managed-by: '{{ .Release.Service }}'
           app.kubernetes.io/name: belugapps
-          app.kubernetes.io/version: '{{ .Chart.Version }}'
-          helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+          app.kubernetes.io/version: '{{ .belug-apps.version }}'
+          helm.sh/chart: belug-apps-{{ .belug-apps.version }}
         name: belugapps-proxy
         namespace: kubeapps-system
       spec:
@@ -297,8 +300,8 @@ vcluster:
               app.kubernetes.io/instance: '{{ .Release.Name }}'
               app.kubernetes.io/managed-by: '{{ .Release.Service }}'
               app.kubernetes.io/name: belugapps
-              app.kubernetes.io/version: '{{ .Chart.Version }}'
-              helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+              app.kubernetes.io/version: '{{ .belug-apps.version }}'
+              helm.sh/chart: belug-apps-{{ .belug-apps.version }}
           spec:
             automountServiceAccountToken: false
             containers:
@@ -313,7 +316,7 @@ vcluster:
                   secretKeyRef:
                     key: api-token
                     name: truenas-creds
-              image: gcr.io/belug-apps/api-proxy:{{ .Chart.Version }}
+              image: gcr.io/belug-apps/api-proxy:{{ .belug-apps.version }}
               livenessProbe:
                 failureThreshold: 6
                 httpGet:
@@ -367,8 +370,8 @@ vcluster:
           app.kubernetes.io/instance: '{{ .Release.Name }}'
           app.kubernetes.io/managed-by: '{{ .Release.Service }}'
           app.kubernetes.io/name: belugapps
-          app.kubernetes.io/version: '{{ .Chart.Version }}'
-          helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+          app.kubernetes.io/version: '{{ .belug-apps.version }}'
+          helm.sh/chart: belug-apps-{{ .belug-apps.version }}
         name: api-proxy
         namespace: kubeapps-system
       spec:

--- a/manifests/default/api-proxy.deployment.yaml
+++ b/manifests/default/api-proxy.deployment.yaml
@@ -30,7 +30,7 @@ spec:
                 secretKeyRef:
                   key: api-token
                   name: truenas-creds
-          image: gcr.io/belug-apps/api-proxy:{{ .Chart.Version }}
+          image: gcr.io/belug-apps/api-proxy:{{ .belug-apps.version }}
           livenessProbe:
             failureThreshold: 6
             httpGet:

--- a/manifests/default/common.labels.yaml
+++ b/manifests/default/common.labels.yaml
@@ -18,5 +18,5 @@ labels:
   app.kubernetes.io/instance: '{{ .Release.Name }}'
   app.kubernetes.io/managed-by: '{{ .Release.Service }}'
   app.kubernetes.io/name: belugapps
-  app.kubernetes.io/version: '{{ .Chart.Version }}'
-  helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+  app.kubernetes.io/version: '{{ .belug-apps.version }}'
+  helm.sh/chart: 'belug-apps-{{ .belug-apps.version }}'


### PR DESCRIPTION
<!-- markdownlint-disable -->
<!--- Please provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->

Manage the api-proxy version separately inside the chart heml.

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When we deploy `Belug-Apps` it tries to pull the image `ghcr.io/belug-apps/api-proxy:0.12.1`, where `0.12.1` is the vcluster version.

### What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Manage properly this version directly inside the Helm chart

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix the current deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting or renaming that would not cause existing functionality to change)
- [ ] Refactoring (no functional changes and no API changes)
- [ ] Build-related changes (improve Github Action workflows)
- [ ] Documentation content changes (add or improve existing documentation)
- [ ] Other (please describe):

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
